### PR TITLE
Fixed #88 and removed unnecessary preference

### DIFF
--- a/app/src/main/java/io/github/subhamtyagi/ocr/Language.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/Language.java
@@ -1,6 +1,7 @@
 package io.github.subhamtyagi.ocr;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -17,7 +18,7 @@ public class Language {
     }
 
     private String code, name;
-    public Language(@NonNull Context c, String code) {
+    public Language(@NonNull Context c, @NonNull String code) {
         String[] languagesNames = c.getResources().getStringArray(R.array.ocr_engine_language);
         String[] languagesCodes = c.getResources().getStringArray(R.array.key_ocr_engine_language_value);
         for (int i = 0; i < languagesCodes.length; i++) {
@@ -26,5 +27,9 @@ public class Language {
                 this.name = languagesNames[i];
             }
         }
+    }
+
+    @Override public String toString() {
+        return getCode();
     }
 }

--- a/app/src/main/java/io/github/subhamtyagi/ocr/Language.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/Language.java
@@ -1,12 +1,8 @@
 package io.github.subhamtyagi.ocr;
 
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public class Language {
     public String getCode() {
@@ -18,17 +14,18 @@ public class Language {
     }
 
     private String code, name;
-    public Language(@NonNull Context c, @NonNull String code) {
+    public Language(@NonNull Context c, @NonNull String seed) {
         String[] languagesNames = c.getResources().getStringArray(R.array.ocr_engine_language);
         String[] languagesCodes = c.getResources().getStringArray(R.array.key_ocr_engine_language_value);
         for (int i = 0; i < languagesCodes.length; i++) {
-            if (languagesCodes[i].equals(code)) {
+            if (languagesCodes[i].equals(seed) || languagesNames[i].equals(seed)) {
                 this.code = languagesCodes[i];
                 this.name = languagesNames[i];
             }
         }
     }
 
+    @NonNull
     @Override public String toString() {
         return getCode();
     }

--- a/app/src/main/java/io/github/subhamtyagi/ocr/Language.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/Language.java
@@ -1,0 +1,30 @@
+package io.github.subhamtyagi.ocr;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class Language {
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private String code, name;
+    public Language(@NonNull Context c, String code) {
+        String[] languagesNames = c.getResources().getStringArray(R.array.ocr_engine_language);
+        String[] languagesCodes = c.getResources().getStringArray(R.array.key_ocr_engine_language_value);
+        for (int i = 0; i < languagesCodes.length; i++) {
+            if (languagesCodes[i].equals(code)) {
+                this.code = languagesCodes[i];
+                this.name = languagesNames[i];
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/subhamtyagi/ocr/MainActivity.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/MainActivity.java
@@ -340,8 +340,12 @@ public class MainActivity extends AppCompatActivity implements TessBaseAPI.Progr
         ConnectivityManager cm = (ConnectivityManager) getSystemService(CONNECTIVITY_SERVICE);
         NetworkInfo ni = cm.getActiveNetworkInfo();
 
-        for (Language language: languages)
-            if (ni != null && ni.isConnected() && languageDataMissing(dataType, language)) {
+        for (Language language: languages) {
+            if (languageDataMissing(dataType, language)) {
+                if (ni == null || !ni.isConnected()) {
+                    Toast.makeText(this, getString(R.string.you_are_not_connected_to_internet), Toast.LENGTH_SHORT).show();
+                    break;
+                }
                 //region show confirmation dialog, On 'yes' download the training data.
                 String msg = String.format(getString(R.string.download_description), language.getName());
                 dialog = new AlertDialog.Builder(this)
@@ -357,10 +361,9 @@ public class MainActivity extends AppCompatActivity implements TessBaseAPI.Progr
                         }).create();
                 dialog.show();
                 //endregion
-            } else {
-                Toast.makeText(this, getString(R.string.you_are_not_connected_to_internet), Toast.LENGTH_SHORT).show();
-                //You are not connected to Internet
             }
+
+        }
     }
     private void downloadLanguageData(final String dataType) {
         downloadLanguageData(dataType, Utils.getTrainingDataLanguages(this));

--- a/app/src/main/java/io/github/subhamtyagi/ocr/SettingsActivity.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/SettingsActivity.java
@@ -9,12 +9,7 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SwitchPreference;
 
 
-/**
- * Settings for App: I think all codes are self explanatory
- */
 public class SettingsActivity extends AppCompatActivity {
-
-    private static final String TAG = "SettingActivity";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -24,37 +19,12 @@ public class SettingsActivity extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.settings, new SettingsFragment())
                 .commit();
-        /*ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }*/
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
-
-            SwitchPreference enableMultipleLang = findPreference(getString(R.string.key_enable_multiple_lang));
-            ListPreference listPreference = findPreference(getString(R.string.key_language_for_tesseract));
-            MultiSelectListPreference multiSelectListPreference = findPreference(getString(R.string.key_language_for_tesseract_multi));
-
-            if (enableMultipleLang.isChecked()) {
-                multiSelectListPreference.setVisible(true);
-                listPreference.setVisible(false);
-            } else {
-                multiSelectListPreference.setVisible(false);
-                listPreference.setVisible(true);
-            }
-
-            enableMultipleLang.setOnPreferenceChangeListener((preference, newValue) -> {
-                boolean b = (boolean) newValue;
-                multiSelectListPreference.setVisible(b);
-                listPreference.setVisible(!b);
-
-                return true;
-            });
-
         }
 
 

--- a/app/src/main/java/io/github/subhamtyagi/ocr/ocr/ImageTextReader.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/ocr/ImageTextReader.java
@@ -4,6 +4,11 @@ import android.graphics.Bitmap;
 
 import com.googlecode.tesseract.android.TessBaseAPI;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.github.subhamtyagi.ocr.Language;
+
 /**
  * This class convert the image to text and return the text on image
  */
@@ -21,14 +26,17 @@ public class ImageTextReader {
      * initialize and train the tesseract engine
      *
      * @param path     a path to training data
-     * @param language language code i.e. selected by user
+     * @param languages language code i.e. selected by user
      * @return the instance of this class for later use
      */
-    public static ImageTextReader geInstance(String path, String language,int pageSegMode, TessBaseAPI.ProgressNotifier progressNotifier) {
+    public static ImageTextReader getInstance(String path, Set<Language> languages, int pageSegMode, TessBaseAPI.ProgressNotifier progressNotifier) {
         try {
             ImageTextReader imageTextReader=new ImageTextReader();
             api = new TessBaseAPI(progressNotifier);
-            imageTextReader.success = api.init(path, language);
+            imageTextReader.success = api.init(path, languages
+                    .stream()
+                    .map(Language::getCode)
+                    .collect(Collectors.joining("+")));
             api.setPageSegMode(pageSegMode);
             return imageTextReader;
         } catch (Exception e) {

--- a/app/src/main/java/io/github/subhamtyagi/ocr/utils/Constants.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/utils/Constants.java
@@ -15,10 +15,7 @@ public class Constants {
 
     public static final String LANGUAGE_CODE = "%s.traineddata";
 
-    public static final String KEY_LANGUAGE_FOR_TESSERACT = "language_for_tesseract";
-    public static final String KEY_ENABLE_MULTI_LANG = "key_enable_multiple_lang";
     public static final String KEY_TESS_TRAINING_DATA_SOURCE = "tess_training_data_source";
-    public static final String KEY_LANGUAGE_FOR_TESSERACT_MULTI = "multi_languages";
     public static final String KEY_GRAYSCALE_IMAGE_OCR = "grayscale_image_ocr";
     public static final String KEY_LAST_USE_IMAGE_LOCATION = "last_use_image_location";
     public static final String KEY_LAST_USE_IMAGE_TEXT = "last_use_image_text";

--- a/app/src/main/java/io/github/subhamtyagi/ocr/utils/SpUtil.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/utils/SpUtil.java
@@ -133,4 +133,9 @@ public class SpUtil {
     }
 
 
+    public void putStringSet(String key, Set<String> value) {
+        Editor editor = mPref.edit();
+        editor.putStringSet(key, value);
+        editor.apply();
+    }
 }

--- a/app/src/main/java/io/github/subhamtyagi/ocr/utils/SpUtil.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/utils/SpUtil.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.preference.PreferenceManager;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Set;
@@ -84,12 +85,12 @@ public class SpUtil {
         return mPref.getBoolean(key, def);
     }
 
-    @Nullable
+    @NonNull
     public String getString(String key) {
         return mPref.getString(key, "");
     }
 
-    @Nullable
+    @NonNull
     public String getString(String key, String def) {
         return mPref.getString(key, def);
     }

--- a/app/src/main/java/io/github/subhamtyagi/ocr/utils/Utils.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/utils/Utils.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 
+import androidx.annotation.NonNull;
+
 import com.googlecode.leptonica.android.AdaptiveMap;
 import com.googlecode.leptonica.android.Binarize;
 import com.googlecode.leptonica.android.Convert;
@@ -75,13 +77,15 @@ public class Utils {
         return SpUtil.getInstance().getString(Constants.KEY_TESS_TRAINING_DATA_SOURCE, "best");
     }
 
-    public static Set<Language> getTrainingDataLanguage(Context c) {
+    public static @NonNull Set<Language> getTrainingDataLanguages(Context c) {
         if (SpUtil.getInstance().getBoolean(Constants.KEY_ENABLE_MULTI_LANG)) {
             return SpUtil.getInstance()
                     .getStringSet(Constants.KEY_LANGUAGE_FOR_TESSERACT_MULTI, Collections.singleton(DEFAULT_LANGUAGE))
-                    .stream().map(code -> new Language(c, code)).collect(Collectors.toSet());
+                    .stream()
+                    .map(code -> new Language(c, code))
+                    .collect(Collectors.toSet());
         } else {
-            return Collections.singleton(new Language(c, SpUtil.getInstance().getString(Constants.KEY_LANGUAGE_FOR_TESSERACT)));
+            return Collections.singleton(new Language(c, SpUtil.getInstance().getString(Constants.KEY_LANGUAGE_FOR_TESSERACT, DEFAULT_LANGUAGE)));
         }
     }
 

--- a/app/src/main/java/io/github/subhamtyagi/ocr/utils/Utils.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/utils/Utils.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.github.subhamtyagi.ocr.Language;
+import io.github.subhamtyagi.ocr.R;
 import kotlin.Triple;
 
 public class Utils {
@@ -80,7 +81,9 @@ public class Utils {
     }
 
     public static @NonNull Set<Language> getTrainingDataLanguages(Context c) {
-        return allLangs(c, SpUtil.getInstance().getStringSet(Constants.KEY_LAST_USED_LANGUAGE_1, Collections.singleton("eng")));
+        return allLangs(c,SpUtil.getInstance().getStringSet(
+                c.getString(R.string.key_language_for_tesseract_multi),
+                Collections.singleton("eng")));
     }
 
     public static int getPageSegMode() {
@@ -97,7 +100,7 @@ public class Utils {
 
     public static Triple<Set<Language>, Set<Language>, Set<Language>> getLast3UsedLanguage(Context c) {
         return new Triple<>(
-                allLangs(c, SpUtil.getInstance().getStringSet(Constants.KEY_LAST_USED_LANGUAGE_1, Collections.singleton("eng"))),
+                allLangs(c, SpUtil.getInstance().getStringSet(c.getString(R.string.key_language_for_tesseract_multi), Collections.singleton("eng"))),
                 allLangs(c, SpUtil.getInstance().getStringSet(Constants.KEY_LAST_USED_LANGUAGE_2, Collections.singleton("hin"))),
                 allLangs(c, SpUtil.getInstance().getStringSet(Constants.KEY_LAST_USED_LANGUAGE_3, Collections.singleton("deu")))
         );
@@ -118,11 +121,11 @@ public class Utils {
         Set<String> l2Codes = l2.stream().map(Language::getCode).collect(Collectors.toSet());
         if (l2.equals(lastUsedLanguage)) {
             SpUtil.getInstance().putStringSet(Constants.KEY_LAST_USED_LANGUAGE_2, l1Codes);
-            SpUtil.getInstance().putStringSet(Constants.KEY_LAST_USED_LANGUAGE_1, lastCodes);
+            SpUtil.getInstance().putStringSet(c.getString(R.string.key_language_for_tesseract_multi), lastCodes);
         } else {
             SpUtil.getInstance().putStringSet(Constants.KEY_LAST_USED_LANGUAGE_3, l2Codes);
             SpUtil.getInstance().putStringSet(Constants.KEY_LAST_USED_LANGUAGE_2, l1Codes);
-            SpUtil.getInstance().putStringSet(Constants.KEY_LAST_USED_LANGUAGE_1, lastCodes);
+            SpUtil.getInstance().putStringSet(c.getString(R.string.key_language_for_tesseract_multi), lastCodes);
         }
 
     }

--- a/app/src/main/java/io/github/subhamtyagi/ocr/utils/Utils.java
+++ b/app/src/main/java/io/github/subhamtyagi/ocr/utils/Utils.java
@@ -1,6 +1,7 @@
 package io.github.subhamtyagi.ocr.utils;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.graphics.Bitmap;
 
 import com.googlecode.leptonica.android.AdaptiveMap;
@@ -13,7 +14,11 @@ import com.googlecode.leptonica.android.Rotate;
 import com.googlecode.leptonica.android.Skew;
 import com.googlecode.leptonica.android.WriteFile;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.github.subhamtyagi.ocr.Language;
 
 public class Utils {
 
@@ -66,36 +71,18 @@ public class Utils {
         return SpUtil.getInstance().getBoolean(Constants.KEY_PERSIST_DATA, true);
     }
 
-    public static String getTesseractStringForMultipleLanguages(Set<String> langs) {
-        if (langs == null) return DEFAULT_LANGUAGE;
-        StringBuilder rLanguage = new StringBuilder();
-        for (String lang : langs) {
-            rLanguage.append(lang);
-            rLanguage.append("+");
-        }
-        return rLanguage.subSequence(0, rLanguage.toString().lastIndexOf('+')).toString();
-    }
-
     public static String getTrainingDataType() {
         return SpUtil.getInstance().getString(Constants.KEY_TESS_TRAINING_DATA_SOURCE, "best");
     }
 
-    public static String getTrainingDataLanguage() {
+    public static Set<Language> getTrainingDataLanguage(Context c) {
         if (SpUtil.getInstance().getBoolean(Constants.KEY_ENABLE_MULTI_LANG)) {
-            return getTesseractStringForMultipleLanguages(SpUtil.getInstance().getStringSet(Constants.KEY_LANGUAGE_FOR_TESSERACT_MULTI, null));
+            return SpUtil.getInstance()
+                    .getStringSet(Constants.KEY_LANGUAGE_FOR_TESSERACT_MULTI, Collections.singleton(DEFAULT_LANGUAGE))
+                    .stream().map(code -> new Language(c, code)).collect(Collectors.toSet());
         } else {
-            return SpUtil.getInstance().getString(Constants.KEY_LANGUAGE_FOR_TESSERACT, DEFAULT_LANGUAGE);
+            return Collections.singleton(new Language(c, SpUtil.getInstance().getString(Constants.KEY_LANGUAGE_FOR_TESSERACT)));
         }
-
-    }
-
-    public static String setTrainingDataLanguage(String language) {
-        if (SpUtil.getInstance().getBoolean(Constants.KEY_ENABLE_MULTI_LANG)) {
-            return getTesseractStringForMultipleLanguages(SpUtil.getInstance().getStringSet(Constants.KEY_LANGUAGE_FOR_TESSERACT_MULTI, null));
-        } else {
-            return SpUtil.getInstance().getString(Constants.KEY_LANGUAGE_FOR_TESSERACT, DEFAULT_LANGUAGE);
-        }
-
     }
 
     public static int getPageSegMode() {
@@ -110,27 +97,27 @@ public class Utils {
         return SpUtil.getInstance().getString(Constants.KEY_LAST_USE_IMAGE_TEXT, "");
     }
 
-    public static String[] getLast3UsedLanguage() {
-        return new String[]{
-                SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_1, "eng"),
-                SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_2, "hin"),
-                SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_3, "deu")
+    public static Language[] getLast3UsedLanguage(Context c) {
+        return new Language[]{
+                new Language(c, SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_1, "eng")),
+                new Language(c, SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_2, "hin")),
+                new Language(c, SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_3, "deu"))
         };
     }
 
-    public static void setLastUsedLanguage(String lastUsedLanguage) {
-        String l1 = SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_1, "eng");
-        if (lastUsedLanguage.contentEquals(l1)) {
+    public static void setLastUsedLanguage(Context c, Language lastUsedLanguage) {
+        Language l1 = getLast3UsedLanguage(c)[0];
+        if (lastUsedLanguage.equals(l1)) {
             return;
         }
-        String l2 = SpUtil.getInstance().getString(Constants.KEY_LAST_USED_LANGUAGE_2, "hin");
-        if (l2.contentEquals(lastUsedLanguage)) {
-            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_2, l1);
-            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_1, lastUsedLanguage);
+        Language l2 = getLast3UsedLanguage(c)[0];
+        if (l2.equals(lastUsedLanguage)) {
+            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_2, l1.getCode());
+            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_1, lastUsedLanguage.getCode());
         } else {
-            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_3, l2);
-            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_2, l1);
-            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_1, lastUsedLanguage);
+            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_3, l2.getCode());
+            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_2, l1.getCode());
+            SpUtil.getInstance().putString(Constants.KEY_LAST_USED_LANGUAGE_1, lastUsedLanguage.getCode());
         }
 
     }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -30,21 +30,6 @@
             android:title="@string/select_tesseract_data_type"
             app:icon="@drawable/ic_baseline_more_horiz_32" />
 
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/key_enable_multiple_lang"
-            android:summary="@string/multiple_lang_summary"
-            android:title="@string/select_multi_languages_title" />
-
-        <ListPreference
-            android:defaultValue="eng"
-            android:entries="@array/ocr_engine_language"
-            android:entryValues="@array/key_ocr_engine_language_value"
-            android:key="@string/key_language_for_tesseract"
-            android:summary="@string/language"
-            android:title="@string/tess_language_title"
-            app:icon="@drawable/ic_baseline_language_32" />
-
         <MultiSelectListPreference
 
             android:entries="@array/ocr_engine_language"


### PR DESCRIPTION
This fixes some crashes caused by the fact that multiple languages were concatenated as strings (eg "eng+ita") and sent to functions that treated the string as a single language.
These functions now take a `Set<Language>`.

The `ListPreference` for a single language has also been removed, since you can just pick a single one from the multi-select one.